### PR TITLE
Add a 'twoline' option for IP-only display

### DIFF
--- a/Sources/com.nuagic.myip.sdPlugin/code.html
+++ b/Sources/com.nuagic.myip.sdPlugin/code.html
@@ -57,11 +57,17 @@ function connectElgatoStreamDeckSocket(inPort, inPluginUUID, inRegisterEvent, in
     get_ip(settings).then(function(data) {
       //console.log(data);
 			var to_display = []
-      if(settings["ip"]) {
-        if(settings["part"] == "a")
-				  to_display.push(data.ip)
-        else
+      if (settings["ip"]) {
+        if (settings["part"] == "a") {
+          if (settings["twoline"]) {
+            const parts = data.ip.split(/[\.:]/)
+            to_display.push(parts[0] + "." + parts[1] + ".\n" + parts[2] + "." + parts[3])
+          } else {
+            to_display.push(data.ip)
+          }
+        } else {
           to_display.push(data.ip.split(/[\.:]/)[settings["part"]])
+        }
       }
 			if(settings["asn"])
 				to_display.push(data.asn_org.replace(' ', "\n"))

--- a/Sources/com.nuagic.myip.sdPlugin/code_pi.html
+++ b/Sources/com.nuagic.myip.sdPlugin/code_pi.html
@@ -38,6 +38,8 @@
             <option value="3">4th</option>
           </select>
         </div>
+		<input id="twoline" class="sdProperty sdCheckbox" type="checkbox" oninput="setSettings()" value="true">
+		<label for="twoline"><span></span>Show on Two Lines</label>
       </div>
       <div type="checkbox" class="sdpi-item">
         <div class="sdpi-item-label">Provider</div>


### PR DESCRIPTION
I just purchased a Stream Deck and loved your plugin idea, but the display was just too small for my eyes to see easily.

So I forked your code locally added a "two-line" option for the IP address for my own use but in the spirit of open-source I figured I would offer it back so you can add to your plugin, if you so choose.

Enjoy!